### PR TITLE
Add missing "75 characters" option

### DIFF
--- a/popup/options/options.js
+++ b/popup/options/options.js
@@ -504,7 +504,7 @@ function addStylesheetThemesToSelect() {
 
 function addMultilineSaveOptionsToSelect() {
     const charactersText = browser.i18n.getMessage("optionsSaveNewVersionMultilineCharacters");
-    ["10", "20", "50", "100", "200", "500", "1000", "5000"].forEach((count)=>{
+    ["10", "20", "50", "75", "100", "200", "500", "1000", "5000"].forEach((count)=>{
         const optionNode = document.createElement('option');
         optionNode.value = count;
         optionNode.appendChild(document.createTextNode(count + " " + charactersText));


### PR DESCRIPTION
Following up on https://github.com/stephanmahieu/formhistorycontrol-2/issues/26#issuecomment-416288350 :

Form History Control 1.4.0.6 had the option to set the new multiline entry threshold at 75 characters.  This brings that option back in Form History Control II.