### PR TITLE
contextmenu.js: Fix name of "restore field" always being in Dutch

### DIFF
--- a/background/contextmenu.js
+++ b/background/contextmenu.js
@@ -468,7 +468,7 @@ function _initContextMenu(contextmenuAvail) {
     }, onMenuCreated);
     browserContextMenusCreate({
         id: "restoreTextField",
-        title: "Herstel tekst veld", // browser.i18n.getMessage("contextMenuItemRestoreTextField"),
+        title: browser.i18n.getMessage("contextMenuItemRestoreTextField"),
         contexts: contextFillTextField,
         icons: {
             "16": "/theme/icons/menu/16/refresh.png",


### PR DESCRIPTION
For some reason the i18n function was commented out and replaced by the plain string in Dutch.

Bug introduced in commit: 42ed0840e49b34b8fbd3682b1c90b796149c3587

Github Link: https://github.com/stephanmahieu/formhistorycontrol-2/commit/42ed0840e49b34b8fbd3682b1c90b796149c3587#diff-ea8699de705521787fb2df5ebee01d00d0bf47ea18ed6b8f9878390f7686caf5R470

---

Idk Stephan did you forget to undo that comment? :P Also I wonder why nobody noticed for 6 months. (open source, reviews and security-bla-bla-bla :smile: )

EDIT: Current version 2.5.8.0